### PR TITLE
Remove package-lock.json file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "SEP490-G97-FA25",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Deleted the package-lock.json file, possibly to reset dependencies or switch package managers.